### PR TITLE
Feature/apply em size for no width or height

### DIFF
--- a/__fixtures__/two.svg
+++ b/__fixtures__/two.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 48 1" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <title>Rectangle 5</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="19-Separator" transform="translate(-129.000000, -156.000000)" fill="#063855">
+            <g id="Controls/Settings" transform="translate(80.000000, 0.000000)">
+                <g id="Content" transform="translate(0.000000, 64.000000)">
+                    <g id="Group" transform="translate(24.000000, 56.000000)">
+                        <g id="Group-2">
+                            <rect id="Rectangle-5" x="25" y="36" width="48" height="1"></rect>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/cli/__snapshots__/index.test.js.snap
+++ b/src/cli/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`cli --icon 1`] = `
 "import React from \\"react\\";
 
 const One = props => (
-  <svg width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 48 1\\" {...props}>
+  <svg viewBox=\\"0 0 48 1\\" width=\\"1em\\" height=\\"1em\\" {...props}>
     <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
   </svg>
 );

--- a/src/cli/__snapshots__/index.test.js.snap
+++ b/src/cli/__snapshots__/index.test.js.snap
@@ -14,6 +14,20 @@ export default One;
 "
 `;
 
+exports[`cli --icon 2`] = `
+"import React from \\"react\\";
+
+const Two = props => (
+  <svg viewBox=\\"0 0 48 1\\" width=\\"1em\\" height=\\"1em\\" {...props}>
+    <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
+  </svg>
+);
+
+export default Two;
+
+"
+`;
+
 exports[`cli --ids 1`] = `
 "import React from \\"react\\";
 

--- a/src/cli/index.test.js
+++ b/src/cli/index.test.js
@@ -32,6 +32,8 @@ describe('cli', () => {
   it('--icon', async () => {
     const [stdout] = await exec('bin/svgr --icon __fixtures__/one.svg')
     expect(stdout).toMatchSnapshot()
+    const [stdout2] = await exec('bin/svgr --icon __fixtures__/two.svg')
+    expect(stdout2).toMatchSnapshot()
   })
 
   it('--ref', async () => {

--- a/src/h2x/emSize.js
+++ b/src/h2x/emSize.js
@@ -1,13 +1,23 @@
+import { JSXAttribute } from 'h2x-plugin-jsx'
+
+const makeSizeAttr = name => {
+  const attr = new JSXAttribute()
+  attr.name = name
+  attr.value = '1em'
+  attr.litteral = false
+  return attr
+}
+
 const emSize = () => ({
   visitor: {
-    JSXAttribute: {
+    JSXElement: {
       enter(path) {
-        if (
-          path.parent.name === 'svg' &&
-          (path.node.name === 'width' || path.node.name === 'height')
-        ) {
-          path.node.value = '1em'
-          path.node.litteral = false
+        if (path.node.name === 'svg' && !path.node.attributes.some(attr => attr && attr.name === 'width' && attr.value === '1em') && !path.node.attributes.some(attr => attr && attr.name === 'height' && attr.value === '1em')) {
+          const nextAttrs = path.node.attributes.filter(attr => attr.name !== 'width' && attr.name !== 'height');
+          nextAttrs.push(makeSizeAttr('width'));
+          nextAttrs.push(makeSizeAttr('height'));
+          path.node.attributes = nextAttrs;
+          path.replace(path.node);
         }
       },
     },


### PR DESCRIPTION
## Description

For `<svg>`s missing `width/height`, the `--icon` flag should add `width="1em` and `height="1em"` as well. See the test case and the snapshot.