### PR TITLE
Add option to remove dimensions --no-dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Options:
   --ref                            add svgRef prop to svg
   --icon                           use "1em" as width and height
   --no-view-box                    remove viewBox (default: true)
+  --no-dimensions                  remove height and width (default: true)
   --native                         add react-native support with react-native-svg
   --replace-attr-value [old=new]   replace an attribute value
   -p, --precision <value>          set the number of digits in the fractional part (svgo)

--- a/src/cli/__snapshots__/index.test.js.snap
+++ b/src/cli/__snapshots__/index.test.js.snap
@@ -58,6 +58,21 @@ export default One;
 "
 `;
 
+exports[`cli --no-dimensions 1`] = `
+"import React from \\"react\\";
+
+const One = props => (
+  <svg viewBox=\\"0 0 48 1\\" {...props}>
+    <title>Rectangle 5</title>
+    <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
+  </svg>
+);
+
+export default One;
+
+"
+`;
+
 exports[`cli --no-expand-props 1`] = `
 "import React from \\"react\\";
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -27,6 +27,7 @@ program
   .option('--ref', 'add svgRef prop to svg')
   .option('--icon', 'use "1em" as width and height')
   .option('--no-view-box', 'remove viewBox')
+  .option('--no-dimensions', 'remove height and width attributes')
   .option('--native', 'add react-native support with react-native-svg')
   .option(
     '--replace-attr-value [old=new]',

--- a/src/cli/index.test.js
+++ b/src/cli/index.test.js
@@ -56,6 +56,11 @@ describe('cli', () => {
     expect(stdout).toMatchSnapshot()
   })
 
+  it('--no-dimensions', async () => {
+    const [stdout] = await exec('bin/svgr --no-dimensions __fixtures__/one.svg')
+    expect(stdout).toMatchSnapshot()
+  })
+
   it('--replace-attr-value', async () => {
     const [stdout] = await exec(
       'bin/svgr --replace-attr-value "#063855=currentColor" __fixtures__/one.svg',

--- a/src/configToOptions.js
+++ b/src/configToOptions.js
@@ -21,6 +21,7 @@ const defaultConfig = {
   expandProps: true,
   title: true,
   keepUselessDefs: false,
+  dimensions: true, // default is keeping dimensions
   ids: false,
   precision: 3, // default to svgo
   semi: undefined, // default to prettier
@@ -42,6 +43,8 @@ function configToOptions(config = {}) {
   function getH2xPlugins() {
     const plugins = [jsx, stripAttribute('xmlns'), removeComments, removeStyle]
     if (config.icon) plugins.push(emSize)
+    if (!config.dimensions)
+      plugins.push(stripAttribute('height'), stripAttribute('width'))
     config.replaceAttrValues.forEach(([oldValue, newValue]) => {
       plugins.push(replaceAttrValue(oldValue, newValue))
     })


### PR DESCRIPTION
#55 

Not the same as #58  because we are using `h2x` `stripAttribute` to strip `height` and `width` attributes. 

Because the `svgo` implementation used in #22 doesn't remove dimension attributes if `viewBox` attribute does not exist. Our implementation allows the user to strip the `height` and `width` no matter what.

This is a good article explaining those properties. https://www.sarasoueidan.com/blog/svg-coordinate-systems/

And also that you don't need the `viewBox` attribute in order to specify `height` and `width`. You can also have `viewBox` without `height` and `width` (in which case `viewBox` is irrelevant and `height` and `width` are 100%)

https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js