### PR TITLE
Make `removeTitle` usage more clear in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ transforming it into a component.
 
 ### Title
 
-Remove the title from SVG. See
+Setting this to `false` will remove the title from SVG. See
 [SVGO `removeTitle` plugin](https://github.com/svg/svgo).
 
 | Default | CLI Override | API Override    |


### PR DESCRIPTION
I had some confusion when reading the `removeTitle` option, thought I'd clear things up for anyone else reading it. 