### PR TITLE
when ids are to be kept, do not minify them

### DIFF
--- a/src/configToOptions.js
+++ b/src/configToOptions.js
@@ -62,7 +62,7 @@ function configToOptions(config = {}) {
     else if (config.title) plugins.push({ removeTitle: false })
     if (config.viewBox) plugins.push({ removeViewBox: false })
     if (config.keepUselessDefs) plugins.push({ removeUselessDefs: false })
-    if (config.ids) plugins.push({ cleanupIDs: { remove: false } })
+    if (config.ids) plugins.push({ cleanupIDs: { remove: false, minify: false } })
     if (config.precision === 'number')
       svgoConfig.floatPrecision = Number(svgoConfig.precision)
     return svgoConfig


### PR DESCRIPTION
Minifying the svg ids, basically defeats the purpose of keeping them, and causes various issues.