### PR TITLE
fix(prettier): Add default parser for prettier

### DIFF
--- a/src/configToOptions.js
+++ b/src/configToOptions.js
@@ -21,6 +21,7 @@ const defaultConfig = {
   jsxBracketSameLine: undefined, // default to prettier
   keepUselessDefs: false,
   native: false,
+  parser: 'babylon', // default to prettier
   precision: 3, // default to svgo
   prettier: true,
   ref: false,
@@ -77,6 +78,7 @@ function configToOptions(config = {}) {
       trailingComma: config.trailingComma,
       bracketSpacing: config.bracketSpacing,
       jsxBracketSameLine: config.jsxBracketSameLine,
+      parser: config.parser
     }
   }
 

--- a/src/plugins/prettier.test.js
+++ b/src/plugins/prettier.test.js
@@ -2,12 +2,12 @@ import prettier from './prettier'
 
 describe('prettier', () => {
   it('should prettify code', () => {
-    const result = prettier(`const foo = <div></div>`)
+    const result = prettier(`const foo = <div></div>`, { parser: 'babylon' })
     expect(result).toBe('const foo = <div />;\n')
   })
 
   it('should support options', () => {
-    const result = prettier(`const foo = <div></div>`, { semi: false })
+    const result = prettier(`const foo = <div></div>`, { semi: false, parser: 'babylon' })
     expect(result).toBe('const foo = <div />\n')
   })
 })


### PR DESCRIPTION
Prettier is no longer support default parser since 1.13.0. This change is to add `parser: 'babylon'` into prettier options (and fix the breaking test).

Fix: https://github.com/smooth-code/svgr/issues/108