### PR TITLE
Add Prettier support for editorconfig file

### DIFF
--- a/packages/core/src/plugins/prettier.js
+++ b/packages/core/src/plugins/prettier.js
@@ -4,7 +4,9 @@ import merge from 'lodash/merge'
 export default async (code, config = {}, state = {}) => {
   if (!config.prettier) return code
   const filePath = state.filePath || process.cwd()
-  const prettierRcConfig = await prettier.resolveConfig(filePath)
+  const prettierRcConfig = await prettier.resolveConfig(filePath, {
+    editorconfig: true,
+  })
   return prettier.format(
     code,
     merge({ parser: 'babylon' }, prettierRcConfig, config.prettierConfig || {}),

--- a/packages/core/src/plugins/prettier.test.js
+++ b/packages/core/src/plugins/prettier.test.js
@@ -22,4 +22,22 @@ describe('prettier', () => {
     )
     expect(result).toBe('const foo = <div />;\n')
   })
+
+  it('should resolve the prettier config with the editorconfig option', async () => {
+    // only mock prettier `resolveConfig` method
+    jest.mock('prettier', () =>
+      Object.assign(require.requireActual('prettier'), {
+        resolveConfig: jest.fn(),
+      }),
+    )
+    /* eslint-disable global-require */
+    const prettierPlugin = require('./prettier').default
+    const { resolveConfig } = require('prettier')
+    /* eslint-enable global-require */
+
+    await prettierPlugin(`const foo = <div></div>`, { prettier: true })
+    expect(resolveConfig).toHaveBeenCalledWith(expect.any(String), {
+      editorconfig: true,
+    })
+  })
 })


### PR DESCRIPTION
As per https://github.com/smooth-code/svgr/issues/125, this change will allow Prettier to parse and use the `.editorconfig` file (if present).

