### PR TITLE
fix(core): not working first plugin when icon option enabled

### DIFF
--- a/packages/core/src/plugins/__snapshots__/svgo.test.js.snap
+++ b/packages/core/src/plugins/__snapshots__/svgo.test.js.snap
@@ -20,4 +20,6 @@ exports[`svgo should optimize svg 1`] = `"<svg width=\\"88\\" height=\\"88\\" xm
 
 exports[`svgo should support config.svgoConfig 1`] = `"<svg width=\\"88\\" height=\\"88\\" xmlns=\\"http://www.w3.org/2000/svg\\"><desc>Created with Sketch.</desc><g stroke=\\"#063855\\" stroke-width=\\"2\\" fill=\\"none\\" fill-rule=\\"evenodd\\" stroke-linecap=\\"square\\"><path d=\\"M51 37L37 51M51 51L37 37\\"/></g></svg>"`;
 
+exports[`svgo should support icon with config.svgoConfig plugins 1`] = `"<svg width=\\"88\\" height=\\"88\\" viewBox=\\"0 0 88 88\\" xmlns=\\"http://www.w3.org/2000/svg\\"><desc>Created with Sketch.</desc><g stroke=\\"#063855\\" stroke-width=\\"2\\" fill=\\"none\\" fill-rule=\\"evenodd\\" stroke-linecap=\\"square\\"><path d=\\"M51 37L37 51M51 51L37 37\\"/></g></svg>"`;
+
 exports[`svgo should use state.filePath to detect configuration 1`] = `"<svg width=\\"88\\" height=\\"88\\" xmlns=\\"http://www.w3.org/2000/svg\\"><desc>Created with Sketch.</desc><g stroke=\\"#063855\\" stroke-width=\\"2\\" fill=\\"none\\" fill-rule=\\"evenodd\\" stroke-linecap=\\"square\\"><path d=\\"M51 37L37 51M51 51L37 37\\"/></g></svg>"`;

--- a/packages/core/src/plugins/mergeConfigs.js
+++ b/packages/core/src/plugins/mergeConfigs.js
@@ -2,10 +2,10 @@ import mergeWith from 'lodash/mergeWith'
 
 function concatArrays(objValue, srcValue) {
   if (Array.isArray(objValue)) {
-    return objValue.concat(srcValue);
+    return objValue.concat(srcValue)
   }
 
-  return undefined; // default value
+  return undefined // default value
 }
 
-export default (...configs) => mergeWith(...configs, concatArrays);
+export default (...configs) => mergeWith(...configs, concatArrays)

--- a/packages/core/src/plugins/mergeConfigs.js
+++ b/packages/core/src/plugins/mergeConfigs.js
@@ -1,0 +1,11 @@
+import mergeWith from 'lodash/mergeWith'
+
+function concatArrays(objValue, srcValue) {
+  if (Array.isArray(objValue)) {
+    return objValue.concat(srcValue);
+  }
+
+  return undefined; // default value
+}
+
+export default (...configs) => mergeWith(...configs, concatArrays);

--- a/packages/core/src/plugins/mergeConfigs.test.js
+++ b/packages/core/src/plugins/mergeConfigs.test.js
@@ -2,37 +2,51 @@ import mergeConfigs from './mergeConfigs'
 
 describe('mergeConfigs', () => {
   it('should merge objects', () => {
-    const result = mergeConfigs({ param1: 'value1' }, { param2: 'value2' }, { param3: 'value3' });
-    expect(result).toEqual({ param1: 'value1', param2: 'value2', param3: 'value3' })
+    const result = mergeConfigs(
+      { param1: 'value1' },
+      { param2: 'value2' },
+      { param3: 'value3' },
+    )
+    expect(result).toEqual({
+      param1: 'value1',
+      param2: 'value2',
+      param3: 'value3',
+    })
   })
 
   it('should merge arrays in objects', () => {
     const result = mergeConfigs(
       { param1: ['value1'] },
       { param1: ['value2'] },
-      { param1: ['value3'] }
-    );
-    expect(result).toEqual({ param1: [ 'value1', 'value2', 'value3' ] })
+      { param1: ['value3'] },
+    )
+    expect(result).toEqual({ param1: ['value1', 'value2', 'value3'] })
   })
 
   it('should merge arrays on object second level', () => {
     const result = mergeConfigs(
       { level1: { level2: ['value1'] } },
       { level1: { level2: ['value2'] } },
-      { level1: { level2: ['value3'] } });
-    expect(result).toEqual({ level1: { level2: ['value1', 'value2', 'value3'] } })
+      { level1: { level2: ['value3'] } },
+    )
+    expect(result).toEqual({
+      level1: { level2: ['value1', 'value2', 'value3'] },
+    })
   })
 
   it('should merge arrays on objects second level with additional params', () => {
     const result = mergeConfigs(
       { level1: { level2: ['value1'], param1: 'value1' } },
       { level1: { level2: ['value2'], param2: 'value2' } },
-      { level1: { level2: ['value3'], param3: 'value3' } });
-    expect(result).toEqual(
-      { level1: { level2: ['value1',
-                           'value2',
-                           'value3'], param1: 'value1',
-                                      param2: 'value2',
-                                      param3: 'value3' } })
+      { level1: { level2: ['value3'], param3: 'value3' } },
+    )
+    expect(result).toEqual({
+      level1: {
+        level2: ['value1', 'value2', 'value3'],
+        param1: 'value1',
+        param2: 'value2',
+        param3: 'value3',
+      },
+    })
   })
 })

--- a/packages/core/src/plugins/mergeConfigs.test.js
+++ b/packages/core/src/plugins/mergeConfigs.test.js
@@ -1,0 +1,38 @@
+import mergeConfigs from './mergeConfigs'
+
+describe('mergeConfigs', () => {
+  it('should merge objects', () => {
+    const result = mergeConfigs({ param1: 'value1' }, { param2: 'value2' }, { param3: 'value3' });
+    expect(result).toEqual({ param1: 'value1', param2: 'value2', param3: 'value3' })
+  })
+
+  it('should merge arrays in objects', () => {
+    const result = mergeConfigs(
+      { param1: ['value1'] },
+      { param1: ['value2'] },
+      { param1: ['value3'] }
+    );
+    expect(result).toEqual({ param1: [ 'value1', 'value2', 'value3' ] })
+  })
+
+  it('should merge arrays on object second level', () => {
+    const result = mergeConfigs(
+      { level1: { level2: ['value1'] } },
+      { level1: { level2: ['value2'] } },
+      { level1: { level2: ['value3'] } });
+    expect(result).toEqual({ level1: { level2: ['value1', 'value2', 'value3'] } })
+  })
+
+  it('should merge arrays on objects second level with additional params', () => {
+    const result = mergeConfigs(
+      { level1: { level2: ['value1'], param1: 'value1' } },
+      { level1: { level2: ['value2'], param2: 'value2' } },
+      { level1: { level2: ['value3'], param3: 'value3' } });
+    expect(result).toEqual(
+      { level1: { level2: ['value1',
+                           'value2',
+                           'value3'], param1: 'value1',
+                                      param2: 'value2',
+                                      param3: 'value3' } })
+  })
+})

--- a/packages/core/src/plugins/svgo.js
+++ b/packages/core/src/plugins/svgo.js
@@ -3,10 +3,13 @@ import cosmiconfig from 'cosmiconfig'
 import mergeWith from 'lodash/mergeWith'
 import isArray from 'lodash/isArray'
 
+
 function concatArrays(objValue, srcValue) {
   if (isArray(objValue)) {
     return objValue.concat(srcValue);
   }
+
+  return undefined; // default value
 }
 
 const explorer = cosmiconfig('svgo', {

--- a/packages/core/src/plugins/svgo.js
+++ b/packages/core/src/plugins/svgo.js
@@ -1,16 +1,6 @@
 import SVGO from 'svgo'
 import cosmiconfig from 'cosmiconfig'
-import mergeWith from 'lodash/mergeWith'
-import isArray from 'lodash/isArray'
-
-
-function concatArrays(objValue, srcValue) {
-  if (isArray(objValue)) {
-    return objValue.concat(srcValue);
-  }
-
-  return undefined; // default value
-}
+import mergeConfigs from './mergeConfigs';
 
 const explorer = cosmiconfig('svgo', {
   searchPlaces: [
@@ -36,7 +26,7 @@ export default async (code, config = {}, state = {}) => {
   const filePath = state.filePath || process.cwd()
   const svgoRcConfig = await explorer.search(filePath)
   const svgo = new SVGO(
-    mergeWith(getBaseSvgoConfig(config), svgoRcConfig, config.svgoConfig, concatArrays),
+    mergeConfigs(getBaseSvgoConfig(config), svgoRcConfig, config.svgoConfig),
   )
   const { data } = await svgo.optimize(code)
   return data

--- a/packages/core/src/plugins/svgo.js
+++ b/packages/core/src/plugins/svgo.js
@@ -1,6 +1,6 @@
 import SVGO from 'svgo'
 import cosmiconfig from 'cosmiconfig'
-import mergeConfigs from './mergeConfigs';
+import mergeConfigs from './mergeConfigs'
 
 const explorer = cosmiconfig('svgo', {
   searchPlaces: [

--- a/packages/core/src/plugins/svgo.js
+++ b/packages/core/src/plugins/svgo.js
@@ -1,6 +1,13 @@
 import SVGO from 'svgo'
 import cosmiconfig from 'cosmiconfig'
-import merge from 'lodash/merge'
+import mergeWith from 'lodash/mergeWith'
+import isArray from 'lodash/isArray'
+
+function concatArrays(objValue, srcValue) {
+  if (isArray(objValue)) {
+    return objValue.concat(srcValue);
+  }
+}
 
 const explorer = cosmiconfig('svgo', {
   searchPlaces: [
@@ -26,7 +33,7 @@ export default async (code, config = {}, state = {}) => {
   const filePath = state.filePath || process.cwd()
   const svgoRcConfig = await explorer.search(filePath)
   const svgo = new SVGO(
-    merge(getBaseSvgoConfig(config), svgoRcConfig, config.svgoConfig),
+    mergeWith(getBaseSvgoConfig(config), svgoRcConfig, config.svgoConfig, concatArrays),
   )
   const { data } = await svgo.optimize(code)
   return data

--- a/packages/core/src/plugins/svgo.test.js
+++ b/packages/core/src/plugins/svgo.test.js
@@ -31,6 +31,16 @@ describe('svgo', () => {
     expect(result).toMatchSnapshot()
   })
 
+  it('should support icon with config.svgoConfig plugins', async () => {
+    const result = await svgo(baseSvg, {
+      svgo: true,
+      icon: true,
+      svgoConfig: { plugins: [{ removeDesc: false }] },
+    })
+
+    expect(result).toMatchSnapshot()
+  })
+
   it('should use state.filePath to detect configuration', async () => {
     const result = await svgo(
       baseSvg,


### PR DESCRIPTION
Hello! Just got not working plugin when enable `icon` option. 

Problem:
not working config: 
```
{
  icon: true,
  plugins: [ { removeDesc: false } ]
}
```

working config:
```
{
  icon: true,
  plugins: [ {}, { removeDesc: false } ]
}
```

Solution: add lodash merge function for concat arrays instead merge them and add test for it.