### PR TITLE
Fix broken "optimized configuration" link in @svgr/webpack

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -77,7 +77,7 @@ const App = () => (
 
 ### Use your own Babel configuration
 
-By default, `@svgr/webpack` includes a `babel-loader` with [optimized configuration](https://github.com/smooth-code/svgr/blob/master/src/webpack.js). In some case you may want to apply a custom one (if you are using Preact for an example). You can turn off Babel transformation by specifying `babel: false` in options.
+By default, `@svgr/webpack` includes a `babel-loader` with [optimized configuration](https://github.com/smooth-code/svgr/blob/master/packages/webpack/src/index.js). In some case you may want to apply a custom one (if you are using Preact for an example). You can turn off Babel transformation by specifying `babel: false` in options.
 
 ```js
 // Example using preact


### PR DESCRIPTION
The `optimized configuration` redirects to a 404 page.