### PR TITLE
Fix config loading

### DIFF
--- a/__fixtures__/overrides.config.js
+++ b/__fixtures__/overrides.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  expandProps: false,
+  dimensions: false,
+  svgo: false,
+  prettier: false,
+}

--- a/packages/cli/src/__snapshots__/index.test.js.snap
+++ b/packages/cli/src/__snapshots__/index.test.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cli should not override config with cli defaults 1`] = `
+"import React from 'react'
+
+const File = () => <svg viewBox=\\"0 0 48 1\\" version={1.1} xmlnsXlink=\\"http://www.w3.org/1999/xlink\\">
+  <title>
+    Rectangle 5
+  </title>
+  <desc>
+    Created with Sketch.
+  </desc>
+  <defs />
+  <g id=\\"Page-1\\" stroke=\\"none\\" strokeWidth={1} fill=\\"none\\" fillRule=\\"evenodd\\">
+    <g id=\\"19-Separator\\" transform=\\"translate(-129.000000, -156.000000)\\" fill=\\"#063855\\">
+      <g id=\\"Controls/Settings\\" transform=\\"translate(80.000000, 0.000000)\\">
+        <g id=\\"Content\\" transform=\\"translate(0.000000, 64.000000)\\">
+          <g id=\\"Group\\" transform=\\"translate(24.000000, 56.000000)\\">
+            <g id=\\"Group-2\\">
+              <rect id=\\"Rectangle-5\\" x={25} y={36} width={48} height={1} />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>
+
+
+export default File
+"
+`;
+
 exports[`cli should support --prettier-config as file 1`] = `
 "import React from 'react'
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -114,6 +114,19 @@ async function run() {
 
   const config = { ...program }
 
+  if (config.expandProps === true) {
+    delete config.expandProps
+  }
+  if (config.dimensions === true) {
+    delete config.dimensions
+  }
+  if (config.svgo === true) {
+    delete config.svgo
+  }
+  if (config.prettier === true) {
+    delete config.prettier
+  }
+
   if (config.template) {
     try {
       const template = require(path.join(process.cwd(), program.template)) // eslint-disable-line global-require, import/no-dynamic-require

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -168,4 +168,15 @@ describe('cli', () => {
     },
     10000,
   )
+
+  it(
+    'should not override config with cli defaults',
+    async () => {
+      const result = await cli(
+        '__fixtures__/simple/file.svg --config=__fixtures__/overrides.config.js',
+      )
+      expect(result).toMatchSnapshot()
+    },
+    10000,
+  )
 })

--- a/packages/cli/src/util.js
+++ b/packages/cli/src/util.js
@@ -9,7 +9,7 @@ export const stat = util.promisify(fs.stat)
 
 export async function convertFile(filePath, { config, ...options } = {}) {
   const code = await readFile(filePath, 'utf-8')
-  const rcConfig = await resolveConfig(config || filePath)
+  const rcConfig = await resolveConfig(filePath, config)
   return convert(code, { ...rcConfig, ...options }, { filePath })
 }
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -28,11 +28,9 @@ export async function resolveConfig(searchFrom, configFile) {
   if (configFile == null) {
     const result = await explorer.search(searchFrom)
     return result ? result.config : null
-  } else {
-    const result = await explorer.load(configFile)
-    return result ? result.config : null
   }
-
+  const result = await explorer.load(configFile)
+  return result ? result.config : null
 }
 
 export async function resolveConfigFile(filePath) {

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -24,9 +24,15 @@ const explorer = cosmiconfig('svgr', {
   rcExtensions: true,
 })
 
-export async function resolveConfig(filePath) {
-  const result = await explorer.search(filePath)
-  return result ? result.config : null
+export async function resolveConfig(searchFrom, configFile) {
+  if (configFile == null) {
+    const result = await explorer.search(searchFrom)
+    return result ? result.config : null
+  } else {
+    const result = await explorer.load(configFile)
+    return result ? result.config : null
+  }
+
 }
 
 export async function resolveConfigFile(filePath) {


### PR DESCRIPTION
Ref https://github.com/smooth-code/svgr/issues/174

In this diff I fixed loading config from custom path specified in
`--config`.

Current behaviour is loading only `svg.config.js` in directory of
specified in `--config` file. This is not intuitive.

Also fixed the problem of overriding options specified in config by
defaults from cli.