### PR TITLE
fix: prevent babel reading babel.config.js

### DIFF
--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -25,6 +25,8 @@ function svgrLoader(source) {
         jsCode,
         {
           babelrc: false,
+          // Unless having this, babel will merge the config with global 'babel.config.js' which may causes some problems such as using react-hot-loader/babel in babel.config.js
+          configFile: false,
           presets: [
             '@babel/preset-react',
             ['@babel/preset-env', { modules: false }],


### PR DESCRIPTION
## Summary

When use `@svgr/webpack` as loader in webpack and has a `babel.config.js` in project at the same time, svgr will read `babel.config.js` which will be merged to it's own config. This may causes some problems. For exmaple when I use [react-hot-loader](https://github.com/gaearon/react-hot-loader) in `babel.config.js`, svgr throw an error
```
TypeError: Property value expected type of string but got null
```

Of course, if I change my own `babel.config.js` to `.babelrc`, then I can solve the problem because of `babelrc: false`

So, like `babelrc: false`, `configFile: false` prevent babel reading `babel.config.js`.

## Test plan
This is my `babel.config.js`
![image](https://user-images.githubusercontent.com/13817144/46701621-eb305d00-cc52-11e8-8da8-5575b16daf60.png)

when use `@svgr/webpack` to deal svg here is the output
![image](https://user-images.githubusercontent.com/13817144/46701693-29c61780-cc53-11e8-81bc-ce33ae528d11.png)

but after add `configFile: false` the output is success
![image](https://user-images.githubusercontent.com/13817144/46701730-4cf0c700-cc53-11e8-9638-2ddf4635ac8f.png)

