### PR TITLE
[@svgr/babel-plugin-transform-svg-component] Fix parsing error of JSX template export statements

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/util.js
+++ b/packages/babel-plugin-transform-svg-component/src/util.js
@@ -72,7 +72,9 @@ export const getExport = ({ template }, opts) => {
   if (opts.state.caller && opts.state.caller.previousExport) {
     result += `${opts.state.caller.previousExport}\n`
     result += `export { ${exportName} as ReactComponent }`
-    return template.ast(result)
+    return template.ast(result, {
+      plugins: ['jsx'],
+    })
   }
 
   result += `export default ${exportName}`


### PR DESCRIPTION
When enabling the `ref` option the compilation will fail due to a `SyntaxError` on the _unexpected token_ `<`:

```sh
ERROR in ./src/components/molecules/core/ErrorState404/styled/svg/fragments/space.svg
Module build failed (from ./node_modules/@svgr/webpack/lib/index.js):
SyntaxError: Unexpected token (2:52)
  1 | /* @babel/template */;
> 2 | const ForwardRef = React.forwardRef((props, ref) => <SvgSpace svgRef={ref} {...props} />)
    |                                                    ^
  3 | 
  4 | export default __webpack_public_path__ + "static/space.fea3855e.svg";
  5 | export { ForwardRef as ReactComponent }
```

This is caused by the [util function `getExport`][src-util-func] that creates the JSX export statements.
The root cause is that the [Babel's AST template function][babel-doc-template] is called without adding the `jsx` plugin which results in the _unexpected token_ `<` which is part of the JSX spec.

To fix the error the `jsx` plugin has been added to the array of enabled plugins for the Babel AST template.

[babel-doc-template]: https://babeljs.io/docs/en/babel-template#templatecode-opts
[src-util-func]: https://github.com/smooth-code/svgr/blob/master/packages/babel-plugin-transform-svg-component/src/util.js#L61
[src-default-template]: https://github.com/smooth-code/svgr/blob/master/packages/babel-plugin-transform-svg-component/src/index.js