### PR TITLE
Handle JSX elements with spread operator with remove-jsx-attribute plugin

### DIFF
--- a/packages/babel-plugin-remove-jsx-attribute/src/index.js
+++ b/packages/babel-plugin-remove-jsx-attribute/src/index.js
@@ -4,7 +4,8 @@ const removeJSXAttribute = (api, opts) => ({
       if (!opts.elements.includes(path.node.name.name)) return
 
       path.get('attributes').forEach(attribute => {
-        if (opts.attributes.includes(attribute.node.name.name)) {
+        const nodeName = attribute.node.name;
+        if (nodeName && opts.attributes.includes(nodeName.name)) {
           attribute.remove()
         }
       })

--- a/packages/babel-plugin-remove-jsx-attribute/src/index.test.js
+++ b/packages/babel-plugin-remove-jsx-attribute/src/index.test.js
@@ -19,4 +19,13 @@ describe('plugin', () => {
       }),
     ).toMatchInlineSnapshot(`"<div foo><span /></div>;"`)
   })
+
+  it('should not throw error when spread operator is used', () => {
+    expect(
+      testPlugin('<div foo><span foo {...props} /></div>', {
+        elements: ['span'],
+        attributes: ['foo'],
+      }),
+    ).toMatchInlineSnapshot(`"<div foo><span {...props} /></div>;"`)
+  })
 })


### PR DESCRIPTION
## Summary
With the `remove-jsx-attribute` plugin, if you run an element with a spread operator, it would throw an exception because the `JSXSpreadAttribute` AST node does not have a `name` attribute.

In order to allow continue checking for removal of attributes, the PR updates the code so that we make sure that there is a node name to check before we make the comparison to remove it.

## Test plan
Wrote a test with a JSX element with spread operator. It failed before the code modification and passes afterwards.