### PR TITLE
docs: fix code example for replace-attr-values

### DIFF
--- a/website/src/pages/docs/cli.mdx
+++ b/website/src/pages/docs/cli.mdx
@@ -55,11 +55,11 @@ $ npx @svgr/cli < icons/web/wifi-icon.svg > icons/web/WifiIcon.js
 To create icons, two options are important:
 
 - `--icon`: viewBox is preserved and SVG inherits text size
-- `--replace-attr-values "#000000=currentColor"`: "#000000" is replaced by
+- `--replace-attr-values "#000=currentColor"`: "#000" is replaced by
   "currentColor" and SVG inherits text color
 
 ```
-$ npx @svgr/cli --icon --replace-attr-values "#000000=currentColor" my-icon.svg
+$ npx @svgr/cli --icon --replace-attr-values "#000=currentColor" my-icon.svg
 ```
 
 ## Target React Native


### PR DESCRIPTION
## Summary

Fix documentation leading to issue #261.
As SVGO simplifies colors like `#000000` to `#000`, example was misleading.
