### PR TITLE
chore(packages): replace repository field with npm-friendly link

### DIFF
--- a/packages/babel-plugin-add-jsx-attribute/package.json
+++ b/packages/babel-plugin-add-jsx-attribute/package.json
@@ -3,7 +3,7 @@
   "description": "Add JSX attribute",
   "version": "4.0.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-add-jsx-attribute",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-remove-jsx-attribute/package.json
+++ b/packages/babel-plugin-remove-jsx-attribute/package.json
@@ -3,7 +3,7 @@
   "description": "Remove JSX attribute",
   "version": "4.0.3",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-remove-jsx-attribute",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-remove-jsx-empty-expression/package.json
+++ b/packages/babel-plugin-remove-jsx-empty-expression/package.json
@@ -3,7 +3,7 @@
   "description": "Remove JSX empty expression",
   "version": "4.0.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-remove-jsx-empty-expression",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-replace-jsx-attribute-value/package.json
+++ b/packages/babel-plugin-replace-jsx-attribute-value/package.json
@@ -3,7 +3,7 @@
   "description": "Replace JSX attribute value",
   "version": "4.0.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-replace-jsx-attribute-value",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-svg-dynamic-title/package.json
+++ b/packages/babel-plugin-svg-dynamic-title/package.json
@@ -3,7 +3,7 @@
   "description": "Transform SVG by adding a dynamic title element",
   "version": "4.0.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-svg-dynamic-title",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-svg-em-dimensions/package.json
+++ b/packages/babel-plugin-svg-em-dimensions/package.json
@@ -3,7 +3,7 @@
   "description": "Transform SVG to use em-based dimensions",
   "version": "4.0.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-svg-em-dimensions",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-native-svg/package.json
+++ b/packages/babel-plugin-transform-react-native-svg/package.json
@@ -3,7 +3,7 @@
   "description": "Transform DOM elements into react-native-svg components",
   "version": "4.0.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-transform-react-native-svg",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-svg-component/package.json
+++ b/packages/babel-plugin-transform-svg-component/package.json
@@ -3,7 +3,7 @@
   "description": "Transform SVG into component",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-plugin-transform-svg-component",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -3,7 +3,7 @@
   "description": "SVGR preset that apply transformations from config",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/babel-preset",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@svgr/cli",
   "description": "SVGR command line.",
   "version": "4.1.0",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/cli",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "description": "Transform SVG into React Components.",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/core",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/hast-util-to-babel-ast/package.json
+++ b/packages/hast-util-to-babel-ast/package.json
@@ -3,7 +3,7 @@
   "description": "Transform HAST to Babel AST (JSX)",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/hast-util-to-babel-ast",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/parcel-plugin-svgr/package.json
+++ b/packages/parcel-plugin-svgr/package.json
@@ -3,7 +3,7 @@
   "description": "SVGR Parcel plugin.",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/parcel-plugin-svgr",
   "author": "Mario Pabon <me@mariopabon.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-jsx/package.json
+++ b/packages/plugin-jsx/package.json
@@ -3,7 +3,7 @@
   "description": "Transform SVG into JSX",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/plugin-jsx",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-prettier/package.json
+++ b/packages/plugin-prettier/package.json
@@ -3,7 +3,7 @@
   "description": "Format code using Prettier",
   "version": "4.0.3",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/plugin-prettier",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-svgo/package.json
+++ b/packages/plugin-svgo/package.json
@@ -3,7 +3,7 @@
   "description": "Optimize SVG",
   "version": "4.0.3",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/plugin-svgo",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -3,7 +3,7 @@
   "description": "SVGR Rollup plugin.",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/rollup",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -3,7 +3,7 @@
   "description": "SVGR webpack loader.",
   "version": "4.1.0",
   "main": "lib/index.js",
-  "repository": "git@github.com:smooth-code/svgr.git",
+  "repository": "https://github.com/smooth-code/svgr/tree/master/packages/webpack",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

This PR replaces git+ssh links in repository field with https form for all of the packages. As a consequence, npm will display a link to github on packages sites. See https://github.com/smooth-code/svgr/issues/246 for more details.

## Test plan

The result of a Github badge will be visible in npm pages of the packages.
