### PR TITLE
update(titleProp:true): title should fallback to svg's title

### DIFF
--- a/packages/babel-plugin-svg-dynamic-title/src/index.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.js
@@ -11,20 +11,51 @@ const plugin = ({ types: t }) => ({
         return
       }
 
-      const titleElement = t.jsxElement(
-        t.jsxOpeningElement(t.jsxIdentifier('title'), []),
-        t.jsxClosingElement(t.jsxIdentifier('title')),
-        [t.jsxExpressionContainer(t.identifier('title'))],
-      )
+      function getTitleElement(existingTitleChildren = []) {
+        // create the expression for the title rendering
+        let expression = t.identifier('title')
+        // get the existing title string value
+        const existingTitle = (existingTitleChildren || [])
+          .map(c => c.value)
+          .join()
+        if (existingTitle) {
+          // if title exists
+          // render as follows
+          // {typeof title === "undefined" ? existingTitle : title}
+          expression = t.conditionalExpression(
+            // title === null
+            t.binaryExpression(
+              '===',
+              t.unaryExpression('typeof', expression),
+              t.stringLiteral('undefined'),
+            ),
+            t.stringLiteral(existingTitle),
+            expression,
+          )
+        }
+
+        // create a title element with the given expression
+        return t.jsxElement(
+          t.jsxOpeningElement(t.jsxIdentifier('title'), []),
+          t.jsxClosingElement(t.jsxIdentifier('title')),
+          [t.jsxExpressionContainer(expression)],
+        )
+      }
+
+      // store the title element
+      let titleElement
 
       const hasTitle = path.get('children').some(childPath => {
         if (!childPath.isJSXElement()) return false
         if (childPath.node === titleElement) return false
         if (childPath.node.openingElement.name.name !== 'title') return false
+        titleElement = getTitleElement(childPath.node.children)
         childPath.replaceWith(titleElement)
         return true
       })
 
+      // create a title element if not already create
+      titleElement = titleElement || getTitleElement()
       if (!hasTitle) {
         // path.unshiftContainer is not working well :(
         // path.unshiftContainer('children', titleElement)

--- a/packages/babel-plugin-svg-dynamic-title/src/index.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.js
@@ -21,14 +21,9 @@ const plugin = ({ types: t }) => ({
         if (existingTitle) {
           // if title exists
           // render as follows
-          // {typeof title === "undefined" ? existingTitle : title}
+          // {title === undefined ? existingTitle : title}
           expression = t.conditionalExpression(
-            // title === null
-            t.binaryExpression(
-              '===',
-              t.unaryExpression('typeof', expression),
-              t.stringLiteral('undefined'),
-            ),
+            t.binaryExpression('===', expression, t.identifier('undefined')),
             t.stringLiteral(existingTitle),
             expression,
           )

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.js
@@ -19,7 +19,7 @@ describe('plugin', () => {
 
   it('should add title attribute and fallback to existing title', () => {
     expect(testPlugin('<svg><title>Hello</title></svg>')).toMatchInlineSnapshot(
-      `"<svg><title>{typeof title === \\"undefined\\" ? \\"Hello\\" : title}</title></svg>;"`,
+      `"<svg><title>{title === undefined ? \\"Hello\\" : title}</title></svg>;"`,
     )
   })
 

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.js
@@ -17,9 +17,9 @@ describe('plugin', () => {
     )
   })
 
-  it('should replace existing title by title attribute', () => {
+  it('should add title attribute and fallback to existing title', () => {
     expect(testPlugin('<svg><title>Hello</title></svg>')).toMatchInlineSnapshot(
-      `"<svg><title>{title}</title></svg>;"`,
+      `"<svg><title>{typeof title === \\"undefined\\" ? \\"Hello\\" : title}</title></svg>;"`,
     )
   })
 

--- a/packages/babel-preset/src/index.test.js
+++ b/packages/babel-preset/src/index.test.js
@@ -68,6 +68,24 @@ describe('preset', () => {
                   export default SvgComponent;"
             `)
   })
+  it('should handle titleProp and fallback on existing title', () => {
+    expect(
+      testPreset('<svg><title>Old</title></svg>', {
+        titleProp: true,
+        state: {
+          componentName: 'SvgComponent',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+                  "import React from \\"react\\";
+                  
+                  const SvgComponent = ({
+                    title
+                  }) => <svg><title>{typeof title === \\"undefined\\" ? \\"Old\\" : title}</title></svg>;
+                  
+                  export default SvgComponent;"
+            `)
+  })
 
   it('should handle replaceAttrValues', () => {
     expect(

--- a/packages/babel-preset/src/index.test.js
+++ b/packages/babel-preset/src/index.test.js
@@ -81,7 +81,7 @@ describe('preset', () => {
                   
                   const SvgComponent = ({
                     title
-                  }) => <svg><title>{typeof title === \\"undefined\\" ? \\"Old\\" : title}</title></svg>;
+                  }) => <svg><title>{title === undefined ? \\"Old\\" : title}</title></svg>;
                   
                   export default SvgComponent;"
             `)

--- a/website/src/pages/docs/options.mdx
+++ b/website/src/pages/docs/options.mdx
@@ -134,7 +134,8 @@ Add props to the root SVG tag.
 
 ## Title
 
-Add title tag via title property.
+Add title tag via title property. If titleProp is set to true and no title is provided (`title={undefined}`) at render time, this will
+fallback to existing title element in the svg if exists. 
 
 | Default | CLI Override | API Override        |
 | ------- | ------------ | ------------------- |


### PR DESCRIPTION
## Summary

Fixes #310:  `title` should fallback to SVG's title when titleProps is set to true and no title is provided

I have updated the `@svgr/babel-plugin-svg-dynamic-title` plugin to insert a conditional statement for  rendering title of the SVG. So now, if the `titleProp` is set to true and the SVG has a title element, then the React component will have following conditional statement to render the title
```html
<!-- icon.svg -->
<svg><title>Default Title</title></svg>
```
```diff
<svg>
- {title}
+ {title === undefined ? "Default Title" : title}
</svg>
```
If there is no title in the SVG, then there will be no change in the React component (same is existing).
```html
<svg>
  <title>{title}</title>
</svg>
```

## Test plan

I have update the relevant test case and docs for the implemented functionality.


P.S.: This is my first attempt with a babel plugin's source code :). So please bear with me.