### PR TITLE
[cli] output relative destination paths

### DIFF
--- a/packages/cli/src/__snapshots__/index.test.js.snap
+++ b/packages/cli/src/__snapshots__/index.test.js.snap
@@ -331,19 +331,19 @@ export default SvgFile
 `;
 
 exports[`cli should transform a whole directory and output relative destination paths 1`] = `
-"__fixtures__/cased/PascalCase.svg -> __fixtures_build__/whole/cased/PascalCase.js
-__fixtures__/cased/kebab-case.svg -> __fixtures_build__/whole/cased/KebabCase.js
+"
+__fixtures__/cased/PascalCase.svg -> __fixtures_build__/whole/cased/PascalCase.js
 __fixtures__/cased/camelCase.svg -> __fixtures_build__/whole/cased/CamelCase.js
+__fixtures__/cased/kebab-case.svg -> __fixtures_build__/whole/cased/KebabCase.js
 __fixtures__/cased/multiple---dashes.svg -> __fixtures_build__/whole/cased/MultipleDashes.js
-__fixtures__/simple/file.svg -> __fixtures_build__/whole/simple/File.js
 __fixtures__/complex/skype.svg -> __fixtures_build__/whole/complex/Skype.js
 __fixtures__/complex/telegram.svg -> __fixtures_build__/whole/complex/Telegram.js
-__fixtures__/withPrettierRc/file.svg -> __fixtures_build__/whole/withPrettierRc/File.js
-__fixtures__/withSvgrRc/file.svg -> __fixtures_build__/whole/withSvgrRc/File.js
-__fixtures__/withSvgoYml/file.svg -> __fixtures_build__/whole/withSvgoYml/File.js
-__fixtures__/nesting/one.svg -> __fixtures_build__/whole/nesting/One.js
 __fixtures__/nesting/a/two.svg -> __fixtures_build__/whole/nesting/a/Two.js
-"
+__fixtures__/nesting/one.svg -> __fixtures_build__/whole/nesting/One.js
+__fixtures__/simple/file.svg -> __fixtures_build__/whole/simple/File.js
+__fixtures__/withPrettierRc/file.svg -> __fixtures_build__/whole/withPrettierRc/File.js
+__fixtures__/withSvgoYml/file.svg -> __fixtures_build__/whole/withSvgoYml/File.js
+__fixtures__/withSvgrRc/file.svg -> __fixtures_build__/whole/withSvgrRc/File.js"
 `;
 
 exports[`cli should work with a simple file 1`] = `

--- a/packages/cli/src/__snapshots__/index.test.js.snap
+++ b/packages/cli/src/__snapshots__/index.test.js.snap
@@ -330,6 +330,22 @@ export default SvgFile
 "
 `;
 
+exports[`cli should transform a whole directory and output relative destination paths 1`] = `
+"__fixtures__/cased/PascalCase.svg -> __fixtures_build__/whole/cased/PascalCase.js
+__fixtures__/cased/kebab-case.svg -> __fixtures_build__/whole/cased/KebabCase.js
+__fixtures__/cased/camelCase.svg -> __fixtures_build__/whole/cased/CamelCase.js
+__fixtures__/cased/multiple---dashes.svg -> __fixtures_build__/whole/cased/MultipleDashes.js
+__fixtures__/simple/file.svg -> __fixtures_build__/whole/simple/File.js
+__fixtures__/complex/skype.svg -> __fixtures_build__/whole/complex/Skype.js
+__fixtures__/complex/telegram.svg -> __fixtures_build__/whole/complex/Telegram.js
+__fixtures__/withPrettierRc/file.svg -> __fixtures_build__/whole/withPrettierRc/File.js
+__fixtures__/withSvgrRc/file.svg -> __fixtures_build__/whole/withSvgrRc/File.js
+__fixtures__/withSvgoYml/file.svg -> __fixtures_build__/whole/withSvgoYml/File.js
+__fixtures__/nesting/one.svg -> __fixtures_build__/whole/nesting/One.js
+__fixtures__/nesting/a/two.svg -> __fixtures_build__/whole/nesting/a/Two.js
+"
+`;
+
 exports[`cli should work with a simple file 1`] = `
 "import React from 'react'
 

--- a/packages/cli/src/dirCommand.js
+++ b/packages/cli/src/dirCommand.js
@@ -32,7 +32,7 @@ async function dirCommand(
     const dest = path.resolve(program.outDir, relative)
     const code = await convertFile(src, options)
     outputFileSync(dest, code)
-    process.stdout.write(`${src} -> ${dest}\n`)
+    process.stdout.write(`${src} -> ${path.relative(process.cwd(), dest)}\n`)
     return true
   }
 

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -48,8 +48,9 @@ describe('cli', () => {
     expect(result).toMatchSnapshot()
   }, 10000)
 
-  it('should transform a whole directory', async () => {
-    await cli('--out-dir __fixtures_build__/whole __fixtures__')
+  it('should transform a whole directory and output relative destination paths', async () => {
+    const result = await cli('--out-dir __fixtures_build__/whole __fixtures__')
+    expect(result).toMatchSnapshot()
   }, 10000)
 
   it('should support --prettier-config as json', async () => {

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -50,7 +50,11 @@ describe('cli', () => {
 
   it('should transform a whole directory and output relative destination paths', async () => {
     const result = await cli('--out-dir __fixtures_build__/whole __fixtures__')
-    expect(result).toMatchSnapshot()
+    const sorted = result
+      .split(/\n/)
+      .sort()
+      .join('\n')
+    expect(sorted).toMatchSnapshot()
   }, 10000)
 
   it('should support --prettier-config as json', async () => {


### PR DESCRIPTION
Currently wide output looks bad on half of the screen I use for terminal

```
src/svgs/visibility.svg -> /Users/_________________________________________/src/icons/Visibility.js
```

In this diff I suggest simply cut useless path and get this

```
src/svgs/visibility.svg -> src/icons/Visibility.js
```