### PR TITLE
docs: typo in homepage

### DIFF
--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -28,7 +28,7 @@ import Helmet from 'react-helmet'
         <h2># Why?</h2>
         <ul>
           <li>Easy integration</li>
-          <li>Flexbility</li>
+          <li>Flexibility</li>
           <li>Performances</li>
         </ul>
       </Col>


### PR DESCRIPTION
## Summary

Correct typo in homepage.

## Test plan

`s/Flexbility/Flexibility`