### PR TITLE
Handle the existing title case by using element instead of value (children)

### DIFF
--- a/packages/babel-plugin-svg-dynamic-title/src/index.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.js
@@ -11,20 +11,51 @@ const plugin = ({ types: t }) => ({
         return
       }
 
-      const titleElement = t.jsxElement(
-        t.jsxOpeningElement(t.jsxIdentifier('title'), []),
-        t.jsxClosingElement(t.jsxIdentifier('title')),
-        [t.jsxExpressionContainer(t.identifier('title'))],
-      )
+      function getTitleElement(existingTitleChildren = []) {
+        // create the expression for the title rendering
+        let expression = t.identifier('title')
+        // get the existing title string value
+        const existingTitle = (existingTitleChildren || [])
+          .map(c => c.value)
+          .join()
+        if (existingTitle) {
+          // if title exists
+          // render as follows
+          // {typeof title === "undefined" ? existingTitle : title}
+          expression = t.conditionalExpression(
+            // title === null
+            t.binaryExpression(
+              '===',
+              t.unaryExpression('typeof', expression),
+              t.stringLiteral('undefined'),
+            ),
+            t.stringLiteral(existingTitle),
+            expression,
+          )
+        }
+
+        // create a title element with the given expression
+        return t.jsxElement(
+          t.jsxOpeningElement(t.jsxIdentifier('title'), []),
+          t.jsxClosingElement(t.jsxIdentifier('title')),
+          [t.jsxExpressionContainer(expression)],
+        )
+      }
+
+      // store the title element
+      let titleElement
 
       const hasTitle = path.get('children').some(childPath => {
         if (!childPath.isJSXElement()) return false
         if (childPath.node === titleElement) return false
         if (childPath.node.openingElement.name.name !== 'title') return false
+        titleElement = getTitleElement(childPath.node.children)
         childPath.replaceWith(titleElement)
         return true
       })
 
+      // create a title element if not already create
+      titleElement = titleElement || getTitleElement()
       if (!hasTitle) {
         // path.unshiftContainer is not working well :(
         // path.unshiftContainer('children', titleElement)

--- a/packages/babel-plugin-svg-dynamic-title/src/index.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.js
@@ -21,14 +21,9 @@ const plugin = ({ types: t }) => ({
         if (existingTitle) {
           // if title exists
           // render as follows
-          // {typeof title === "undefined" ? existingTitle : title}
+          // {title === undefined ? existingTitle : title}
           expression = t.conditionalExpression(
-            // title === null
-            t.binaryExpression(
-              '===',
-              t.unaryExpression('typeof', expression),
-              t.stringLiteral('undefined'),
-            ),
+            t.binaryExpression('===', expression, t.identifier('undefined')),
             t.stringLiteral(existingTitle),
             expression,
           )

--- a/packages/babel-plugin-svg-dynamic-title/src/index.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.js
@@ -11,30 +11,35 @@ const plugin = ({ types: t }) => ({
         return
       }
 
-      function getTitleElement(existingTitleChildren = []) {
-        // create the expression for the title rendering
-        let expression = t.identifier('title')
-        // get the existing title string value
-        const existingTitle = (existingTitleChildren || [])
-          .map(c => c.value)
-          .join()
-        if (existingTitle) {
-          // if title exists
-          // render as follows
-          // {title === undefined ? existingTitle : title}
-          expression = t.conditionalExpression(
-            t.binaryExpression('===', expression, t.identifier('undefined')),
-            t.stringLiteral(existingTitle),
-            expression,
-          )
-        }
-
-        // create a title element with the given expression
+      function createTitle(children = []) {
         return t.jsxElement(
           t.jsxOpeningElement(t.jsxIdentifier('title'), []),
           t.jsxClosingElement(t.jsxIdentifier('title')),
-          [t.jsxExpressionContainer(expression)],
+          children,
         )
+      }
+      function getTitleElement(existingTitleChildren = []) {
+        const titleExpression = t.identifier('title')
+        let titleElement = createTitle([
+          t.jsxExpressionContainer(titleExpression),
+        ])
+        if (existingTitleChildren && existingTitleChildren.length) {
+          // if title already exists
+          // render as follows
+          const fallbackTitleElement = createTitle(existingTitleChildren)
+          // {title === undefined ? fallbackTitleElement : titleElement}
+          const conditionalExpressionForTitle = t.conditionalExpression(
+            t.binaryExpression(
+              '===',
+              titleExpression,
+              t.identifier('undefined'),
+            ),
+            fallbackTitleElement,
+            titleElement,
+          )
+          titleElement = t.jsxExpressionContainer(conditionalExpressionForTitle)
+        }
+        return titleElement
       }
 
       // store the title element

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.js
@@ -18,15 +18,16 @@ describe('plugin', () => {
   })
 
   it('should add title element and fallback to existing title', () => {
-    ;['Hello', '{Hello}']
-      .map(titleChildren => `<title>${titleChildren}</title>`)
-      .forEach(existingTitleElement =>
-        expect(
-          testPlugin(`<svg>${existingTitleElement}</svg>`),
-        ).toMatchInlineSnapshot(
-          `"<svg>{title === undefined ? ${existingTitleElement} : <title>{title}</title>}</svg>;"`,
-        ),
-      )
+    // testing when the existing title contains a simple string
+    expect(testPlugin(`<svg><title>Hello</title></svg>`)).toMatchInlineSnapshot(
+      `"<svg>{title === undefined ? <title>Hello</title> : <title>{title}</title>}</svg>;"`,
+    )
+    // testing when the existing title contains an JSXExpression
+    expect(
+      testPlugin(`<svg><title>{"Hello"}</title></svg>`),
+    ).toMatchInlineSnapshot(
+      `"<svg>{title === undefined ? <title>{\\"Hello\\"}</title> : <title>{title}</title>}</svg>;"`,
+    )
   })
   it('should support empty title', () => {
     expect(testPlugin('<svg><title></title></svg>')).toMatchInlineSnapshot(

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.js
@@ -17,12 +17,22 @@ describe('plugin', () => {
     )
   })
 
-  it('should add title attribute and fallback to existing title', () => {
-    expect(testPlugin('<svg><title>Hello</title></svg>')).toMatchInlineSnapshot(
-      `"<svg><title>{title === undefined ? \\"Hello\\" : title}</title></svg>;"`,
+  it('should add title element and fallback to existing title', () => {
+    ;['Hello', '{Hello}']
+      .map(titleChildren => `<title>${titleChildren}</title>`)
+      .forEach(existingTitleElement =>
+        expect(
+          testPlugin(`<svg>${existingTitleElement}</svg>`),
+        ).toMatchInlineSnapshot(
+          `"<svg>{title === undefined ? ${existingTitleElement} : <title>{title}</title>}</svg>;"`,
+        ),
+      )
+  })
+  it('should support empty title', () => {
+    expect(testPlugin('<svg><title></title></svg>')).toMatchInlineSnapshot(
+      `"<svg><title>{title}</title></svg>;"`,
     )
   })
-
   it('should support self closing title', () => {
     expect(testPlugin('<svg><title /></svg>')).toMatchInlineSnapshot(
       `"<svg><title>{title}</title></svg>;"`,

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.js
@@ -19,7 +19,7 @@ describe('plugin', () => {
 
   it('should add title attribute and fallback to existing title', () => {
     expect(testPlugin('<svg><title>Hello</title></svg>')).toMatchInlineSnapshot(
-      `"<svg><title>{typeof title === \\"undefined\\" ? \\"Hello\\" : title}</title></svg>;"`,
+      `"<svg><title>{title === undefined ? \\"Hello\\" : title}</title></svg>;"`,
     )
   })
 

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.js
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.js
@@ -17,9 +17,9 @@ describe('plugin', () => {
     )
   })
 
-  it('should replace existing title by title attribute', () => {
+  it('should add title attribute and fallback to existing title', () => {
     expect(testPlugin('<svg><title>Hello</title></svg>')).toMatchInlineSnapshot(
-      `"<svg><title>{title}</title></svg>;"`,
+      `"<svg><title>{typeof title === \\"undefined\\" ? \\"Hello\\" : title}</title></svg>;"`,
     )
   })
 

--- a/packages/babel-preset/src/index.test.js
+++ b/packages/babel-preset/src/index.test.js
@@ -69,22 +69,26 @@ describe('preset', () => {
             `)
   })
   it('should handle titleProp and fallback on existing title', () => {
-    expect(
-      testPreset('<svg><title>Old</title></svg>', {
-        titleProp: true,
-        state: {
-          componentName: 'SvgComponent',
-        },
-      }),
-    ).toMatchInlineSnapshot(`
+    ;['Hello', '{Hello}']
+      .map(children => `<title>${children}</title>`)
+      .forEach(existingTitle =>
+        expect(
+          testPreset(`<svg>${existingTitle}</svg>`, {
+            titleProp: true,
+            state: {
+              componentName: 'SvgComponent',
+            },
+          }),
+        ).toMatchInlineSnapshot(`
                   "import React from \\"react\\";
                   
                   const SvgComponent = ({
                     title
-                  }) => <svg><title>{title === undefined ? \\"Old\\" : title}</title></svg>;
+                  }) => <svg>{title === undefined ? ${existingTitle} : <title>{title}</title>}</svg>;
                   
                   export default SvgComponent;"
-            `)
+            `),
+      )
   })
 
   it('should handle replaceAttrValues', () => {

--- a/packages/babel-preset/src/index.test.js
+++ b/packages/babel-preset/src/index.test.js
@@ -68,6 +68,24 @@ describe('preset', () => {
                   export default SvgComponent;"
             `)
   })
+  it('should handle titleProp and fallback on existing title', () => {
+    expect(
+      testPreset('<svg><title>Old</title></svg>', {
+        titleProp: true,
+        state: {
+          componentName: 'SvgComponent',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+                  "import React from \\"react\\";
+                  
+                  const SvgComponent = ({
+                    title
+                  }) => <svg><title>{typeof title === \\"undefined\\" ? \\"Old\\" : title}</title></svg>;
+                  
+                  export default SvgComponent;"
+            `)
+  })
 
   it('should handle replaceAttrValues', () => {
     expect(

--- a/packages/babel-preset/src/index.test.js
+++ b/packages/babel-preset/src/index.test.js
@@ -81,7 +81,7 @@ describe('preset', () => {
                   
                   const SvgComponent = ({
                     title
-                  }) => <svg><title>{typeof title === \\"undefined\\" ? \\"Old\\" : title}</title></svg>;
+                  }) => <svg><title>{title === undefined ? \\"Old\\" : title}</title></svg>;
                   
                   export default SvgComponent;"
             `)

--- a/packages/babel-preset/src/index.test.js
+++ b/packages/babel-preset/src/index.test.js
@@ -69,26 +69,40 @@ describe('preset', () => {
             `)
   })
   it('should handle titleProp and fallback on existing title', () => {
-    ;['Hello', '{Hello}']
-      .map(children => `<title>${children}</title>`)
-      .forEach(existingTitle =>
-        expect(
-          testPreset(`<svg>${existingTitle}</svg>`, {
-            titleProp: true,
-            state: {
-              componentName: 'SvgComponent',
-            },
-          }),
-        ).toMatchInlineSnapshot(`
+    // testing when existing title has string as chilren
+    expect(
+      testPreset(`<svg><title>Hello</title></svg>`, {
+        titleProp: true,
+        state: {
+          componentName: 'SvgComponent',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
                   "import React from \\"react\\";
                   
                   const SvgComponent = ({
                     title
-                  }) => <svg>{title === undefined ? ${existingTitle} : <title>{title}</title>}</svg>;
+                  }) => <svg>{title === undefined ? <title>Hello</title> : <title>{title}</title>}</svg>;
                   
                   export default SvgComponent;"
-            `),
-      )
+            `)
+    // testing when existing title has JSXExpression as children
+    expect(
+      testPreset(`<svg><title>{"Hello"}</title></svg>`, {
+        titleProp: true,
+        state: {
+          componentName: 'SvgComponent',
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+                  "import React from \\"react\\";
+                  
+                  const SvgComponent = ({
+                    title
+                  }) => <svg>{title === undefined ? <title>{\\"Hello\\"}</title> : <title>{title}</title>}</svg>;
+                  
+                  export default SvgComponent;"
+            `)
   })
 
   it('should handle replaceAttrValues', () => {

--- a/website/src/pages/docs/options.mdx
+++ b/website/src/pages/docs/options.mdx
@@ -134,7 +134,8 @@ Add props to the root SVG tag.
 
 ## Title
 
-Add title tag via title property.
+Add title tag via title property. If titleProp is set to true and no title is provided (`title={undefined}`) at render time, this will
+fallback to existing title element in the svg if exists. 
 
 | Default | CLI Override | API Override        |
 | ------- | ------------ | ------------------- |


### PR DESCRIPTION
## Summary

Fixes #314 titleProps=true not working as expected for existing title

We need to handle existing `title` element's children with a different strategy. Instead of looping through children and creating a children, we can instead, use all the children and push them into a title element. And from the conditional statement for fallback title, instead of returning a title children, we return the title.
```diff
- {title === undefined ? "Existing_Children" : title}
+ {title === undefined ? <title>{Existing_Children}</title> : <title>{title}</title>}
``` 

## Test plan

I have updated the test case for the same with different type of existing title elements.
```js
// pass
expect(testPlugin(`<svg><title>Hi</title></svg`)). toMatchInlineSnapshot(
`<svg>{title === undefined ? <title>Hi</title> : <title>{title}</title>}</svg>`
)
// pass
expect(testPlugin(`<svg><title>{"Hi"}</title></svg`)). toMatchInlineSnapshot(
`<svg>{title === undefined ? <title>{"Hi"}</title> : <title>{title}</title>}</svg>`
)
```

