### PR TITLE
docs(typescript): refactor typescript template

### DIFF
--- a/website/src/pages/docs/typescript.mdx
+++ b/website/src/pages/docs/typescript.mdx
@@ -46,8 +46,8 @@ module.exports = {
   ) {
     const typeScriptTpl = template.smart({ plugins: ['typescript'] })
     return typeScriptTpl.ast`
-    import * as React from 'react';
-    const ${componentName} = (props: React.SVGProps<SVGSVGElement>) => ${jsx};
+    import React, { SVGProps } from 'react';
+    const ${componentName} = (props: SVGProps<SVGSVGElement>) => ${jsx};
     export default ${componentName};
   `
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Refactors the example typescript template to match the new import paths of React.

## Test plan

The usage of the generated icons is the same as before. Only the build size should be smaller.