### PR TITLE
Fix #331 - Invalid characters in component name

### DIFF
--- a/packages/core/src/state.js
+++ b/packages/core/src/state.js
@@ -3,9 +3,12 @@ import camelcase from 'camelcase'
 
 function getComponentName(state) {
   if (!state.filePath) return 'SvgComponent'
-  const pascalCaseFileName = camelcase(path.parse(state.filePath).name, {
-    pascalCase: true,
-  })
+  const pascalCaseFileName = camelcase(
+    path.parse(state.filePath).name.replace(/[^a-zA-Z0-9_-]/g, ''),
+    {
+      pascalCase: true,
+    },
+  )
   return `Svg${pascalCaseFileName}`
 }
 

--- a/packages/core/src/state.js
+++ b/packages/core/src/state.js
@@ -1,10 +1,12 @@
 import path from 'path'
 import camelcase from 'camelcase'
 
+const validCharacters = /[^a-zA-Z0-9_-]/g
+
 function getComponentName(state) {
   if (!state.filePath) return 'SvgComponent'
   const pascalCaseFileName = camelcase(
-    path.parse(state.filePath).name.replace(/[^a-zA-Z0-9_-]/g, ''),
+    path.parse(state.filePath).name.replace(validCharacters, ''),
     {
       pascalCase: true,
     },

--- a/packages/core/src/state.test.js
+++ b/packages/core/src/state.test.js
@@ -20,6 +20,10 @@ describe('state', () => {
         filePath: '1_big_svg.svg',
         componentName: 'Svg1BigSvg',
       })
+      expect(expandState({ filePath: 'a&b~c-d_e.svg' })).toEqual({
+        filePath: 'a&b~c-d_e.svg',
+        componentName: 'SvgAbcDE',
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

fixes #331 - Filenames may contain invalid characters for javascript variable names, so they need to be removed.

## Test plan

Add a few tests to check that the characters are removed.


@neoziro There a few ways to handle this, but I'm not sure which way is preferred.

1. Remove a few known characters that might cause issues (~!@#%&?)
2. Have a whitelist of characters (`a-zA-Z0-9_-`)

With option 1 we may run into more characters later that need to be added. Option 2 might have the issue of a filename with only invalid characters, or characters that are actually valid but are removed anyways (unicode).
