### PR TITLE
fix(webpack): add recognization for ESM export

### DIFF
--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -34,7 +34,11 @@ function svgrLoader(source) {
     .match(/^module.exports\s*=\s*(.*)/)
   const previousExport = exportMatches
     ? `export default ${exportMatches[1]}`
-    : null
+    : source
+      .toString('utf-8')
+      .startsWith('export ')
+      ? source
+      : null
 
   const tranformSvg = svg =>
     convert(svg, options, {

--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -29,16 +29,16 @@ function svgrLoader(source) {
       })
     })
 
-  const exportMatches = source
-    .toString('utf-8')
-    .match(/^module.exports\s*=\s*(.*)/)
-  const previousExport = exportMatches
-    ? `export default ${exportMatches[1]}`
-    : source
+  let previousExport = null
+  if (source.toString('utf-8').startsWith('export ')) {
+    previousExport = source
+  } else {
+    const exportMatches = source
       .toString('utf-8')
-      .startsWith('export ')
-      ? source
+      .match(/^module.exports\s*=\s*(.*)/)
+    previousExport = exportMatches ? `export default ${exportMatches[1]}`
       : null
+  }
 
   const tranformSvg = svg =>
     convert(svg, options, {
@@ -56,7 +56,7 @@ function svgrLoader(source) {
       .then(result => callback(null, result))
       .catch(err => callback(err))
 
-  if (exportMatches) {
+  if (previousExport) {
     readSvg().then(tranformSvg)
   } else {
     tranformSvg(source)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

New url-loader and  file-loader uses ESM export feature which the @svgr/webpack loader cannot recognize and throw error. #367 

## Test plan

Use new file-loader before @svgr/webpack, see it if works.
